### PR TITLE
Remove explicit references to old crate names 

### DIFF
--- a/page-table/Cargo.toml
+++ b/page-table/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-builtin_macros = { path = "../.verus/source/builtin_macros" }
-builtin = { path = "../.verus/source/builtin" }
-state_machines_macros = { path = "../.verus/source/state_machines_macros" }
 vstd = { path = "../.verus/source/vstd", features = [], default-features = false }
 
 [lib]

--- a/page-table/src/lib.rs
+++ b/page-table/src/lib.rs
@@ -5,9 +5,6 @@
 #[cfg(not(feature="linuxmodule"))]
 extern crate alloc;
 
-extern crate builtin;
-extern crate builtin_macros;
-extern crate state_machines_macros;
 extern crate vstd;
 
 


### PR DESCRIPTION
They don't appear to be necessary, and this will help prepare for the new crate naming scheme (verus-lang/verus/pull/1815).